### PR TITLE
Make build C++ project action runnable from PRs

### DIFF
--- a/.github/workflows/build_cpp_project.yml
+++ b/.github/workflows/build_cpp_project.yml
@@ -2,8 +2,8 @@
 name: Build Win cpp project
 
 on:
-  workflow_call:
   workflow_dispatch:
+  pull_request:
 
 jobs:
   test_cpp_build:

--- a/.github/workflows/build_cpp_project.yml
+++ b/.github/workflows/build_cpp_project.yml
@@ -1,5 +1,5 @@
 ---
-name: Build C++ project (winOS)
+name: Build C++ project
 
 on:
   workflow_dispatch:
@@ -8,7 +8,7 @@ on:
 jobs:
   test_cpp_build:
     runs-on: windows-latest
-    name: Build C++ project (winOS)
+    name: Build C++ (winOS)
     steps:
       - name: Checkout Files
         uses: actions/checkout@v4.1.4

--- a/.github/workflows/build_cpp_project.yml
+++ b/.github/workflows/build_cpp_project.yml
@@ -1,5 +1,5 @@
 ---
-name: Build Win cpp project
+name: Build C++ project (winOS)
 
 on:
   workflow_dispatch:
@@ -8,7 +8,7 @@ on:
 jobs:
   test_cpp_build:
     runs-on: windows-latest
-    name: Build demo
+    name: Build C++ project (winOS)
     steps:
       - name: Checkout Files
         uses: actions/checkout@v4.1.4


### PR DESCRIPTION
# Summary - Make build C++ project action runnable from PRs

## Type of change
- [ ] New feature
- [x] Infrastructure
- [ ] Bugfix

## Description
- Make build C++ project action runnable from PRs

## Checklist
- [x] Code has been formatted
